### PR TITLE
test: establish isolated JSONPath CTS safety baseline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,21 +12,32 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
       - run: zig build test --summary all
+  cts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - run: zig build cts
+      - run: zig build cts -Doptimize=ReleaseSafe
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
-      - run: zig fmt --check jsonpath.zig
+          version: 0.16.0
+      - run: zig fmt --check build.zig jsonpath.zig tests/cts_runner.zig
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
+zig-pkg/
 *.txt
 zig-out

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jsonpath-compliance-test-suite"]
+	path = jsonpath-compliance-test-suite
+	url = https://github.com/jsonpath-standard/jsonpath-compliance-test-suite

--- a/README.md
+++ b/README.md
@@ -1,6 +1,37 @@
 # zig-jsonpath
 A Zig JSONPath library that implements the IETF RFC 9535. 
 
+## Testing
+
+Run the unit tests with Zig 0.16.0 or later:
+
+```sh
+zig build test
+```
+
+The official JSONPath Compliance Test Suite is pinned as a git submodule at
+revision `7be7c1fc28057c91e8eefaf197060fba7ed43acd`. Initialize it once after
+cloning, then run the entire suite with one process-isolated worker per case:
+
+```sh
+git submodule update --init
+zig build cts
+```
+
+The pinned suite contains 456 valid selectors and 247 invalid selectors. The
+current safety baseline is:
+
+- 109 valid passes
+- 347 valid failures
+- 128 invalid selectors rejected
+- 119 invalid selectors accepted
+- 0 crashes
+
+The same counts are expected in Debug and ReleaseSafe. The CTS target reports
+semantic failures without failing the build; it returns a failure only if a
+case crashes or the harness cannot obtain a valid worker result. Broad semantic
+conformance changes are tracked separately from this safety baseline.
+
 ## TODO
 ### Basic Functionality
 - [x] Implement * operator (select all members at current node)

--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mvzr_dep = b.dependency("mvzr", .{});
-    _ = b.addModule("jsonpath", .{
+    const jsonpath_module = b.addModule("jsonpath", .{
         .root_source_file = b.path("jsonpath.zig"),
         .imports = &.{
             .{ .name = "mvzr", .module = mvzr_dep.module("mvzr") },
@@ -52,9 +52,51 @@ pub fn build(b: *std.Build) void {
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
+    const cts_runner_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/cts_runner.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "jsonpath", .module = jsonpath_module },
+            },
+        }),
+    });
+
+    const run_cts_runner_unit_tests = b.addRunArtifact(cts_runner_unit_tests);
+
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
+    test_step.dependOn(&run_cts_runner_unit_tests.step);
+
+    // Run the official JSONPath compliance suite with one isolated process per case.
+    const cts_runner = b.addExecutable(.{
+        .name = "cts-runner",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/cts_runner.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "jsonpath", .module = jsonpath_module },
+            },
+        }),
+    });
+
+    const run_cts = b.addRunArtifact(cts_runner);
+
+    // Pass the pinned suite location as argv[1]. This avoids depending on cwd.
+    run_cts.addFileArg(
+        b.path("jsonpath-compliance-test-suite/cts.json"),
+    );
+
+    // Forward arguments after `--`, primarily for debugging an individual worker.
+    if (b.args) |args| {
+        run_cts.addArgs(args);
+    }
+
+    const cts_step = b.step("cts", "Run the JSONPath compliance test suite");
+    cts_step.dependOn(&run_cts.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,7 +15,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     .fingerprint = 0xc39891c8d8368dd,
 

--- a/jsonpath.zig
+++ b/jsonpath.zig
@@ -1422,10 +1422,16 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
                 // If the next character is a ', we are trying to get a node at the proceeding key, so read characters until we hit another '
                 if (char == '\'') {
                     path_index += 1;
+                    if (path_index >= path.len) {
+                        return JsonPathError.InvalidPath;
+                    }
                     char = path[path_index];
                     // Read characters until we hit another '
                     var escape_next_char: bool = false;
                     while (path_index < path.len and (char != '\'' or escape_next_char)) {
+                        if (char < 0x20) {
+                            return JsonPathError.InvalidPath;
+                        }
                         node_name_buffer.append(char) catch return JsonPathError.OutOfMemory;
                         path_index += 1;
                         if (path_index < path.len) {
@@ -1457,10 +1463,13 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
                         printErr("invalid path: ends with unclosed selector\n", .{});
                         return JsonPathError.InvalidPath;
                     }
+                    if (current_node.* != .object) {
+                        return null;
+                    }
                     // Get the next node
                     const next_node = current_node.object.getPtr(node_name_buffer.items);
                     if (next_node == null) {
-                        return undefined;
+                        return null;
                     }
                     current_node = next_node.?;
                     path_index += 1;
@@ -1539,7 +1548,7 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
                     .Slice => {
                         // Must be Array
                         if (current_node.* != .array) {
-                            return undefined;
+                            return null;
                         }
                         // Read through the expression, getting a start, end, and step
                         // If the step is not defined, then it is 1
@@ -1607,19 +1616,17 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
                         }
                         // If there are characters in the parse_int_buffer, then parse them
                         // Slice array
-                        // If the start is greater than the end, then return undefined
-                        // If the start is greater than the length of the array, then return undefined
+                        // An empty or out-of-bounds range selects no nodes.
                         if (start > end or start > current_node.array.items.len) {
-                            return undefined;
+                            return json.Value{ .array = sliced_array };
                         }
                         // If the end is greater than the length of the array, then set it to the length of the array
                         if (end > current_node.array.items.len) {
                             end = current_node.array.items.len;
                         }
-                        // If the step is 0, then return invalid path
+                        // RFC 9535 defines a zero step as selecting no nodes.
                         if (step == 0) {
-                            printErr("invalid slice expression: step is 0\n", .{});
-                            return JsonPathError.InvalidPath;
+                            return json.Value{ .array = sliced_array };
                         }
                         // If the step is negative, then iterate backwards through the array
                         // If the step is positive, then iterate forwards through the array
@@ -1627,14 +1634,16 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
                         while (start < end) : (start += step) {
                             // Otherwise, we need to evaluate the rest of the path
                             const evaluated_item = try evaluateJsonPathExpression(allocator, path[path_index..], &current_node.array.items[start], .{ .skip_root = true });
-                            sliced_array.append(evaluated_item.?) catch return JsonPathError.OutOfMemory;
+                            if (evaluated_item) |item| {
+                                sliced_array.append(item) catch return JsonPathError.OutOfMemory;
+                            }
                         }
                         return json.Value{ .array = sliced_array };
                     },
                     .Pick => {
                         // Must be Array
                         if (current_node.* != .array) {
-                            return undefined;
+                            return null;
                         }
                         // Loop through the pick list and add the corresponding items to the array
                         var pick_items = std.array_list.Managed(u64).init(allocator);
@@ -1674,25 +1683,28 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
                                 pick_items.append(parsed_int) catch return JsonPathError.OutOfMemory;
                             }
                         }
-                        // If selecting a single item, then return that item as a value (if it exists) instead of an array. If
-                        // it doesn't exist, then return undefined
+                        // Return a single selected item as a value, or no match if it is absent.
                         if (!select_multiple) {
                             if (pick_items.items.len == 0) {
-                                return undefined;
+                                return null;
                             }
-                            return current_node.array.items[pick_items.items[0]];
+                            const index = pick_items.items[0];
+                            if (index >= current_node.array.items.len) return null;
+                            return current_node.array.items[index];
                         }
                         // Loop through the pick list and add the corresponding items to the array
                         path_index += 1;
                         for (pick_items.items) |index| {
+                            if (index >= current_node.array.items.len) continue;
                             const evaluated_item = try evaluateJsonPathExpression(allocator, path[path_index..], &current_node.array.items[index], .{ .skip_root = true });
-                            sliced_array.append(evaluated_item.?) catch return JsonPathError.OutOfMemory;
+                            if (evaluated_item) |item| {
+                                sliced_array.append(item) catch return JsonPathError.OutOfMemory;
+                            }
                         }
-                        // If selecting a single item, then return that item as a value (if it exists) instead of an array. If
-                        // it doesn't exist, then return undefined
+                        // Return a single selected item as a value, or no match if it is absent.
                         if (!select_multiple) {
                             if (sliced_array.items.len == 0) {
-                                return undefined;
+                                return null;
                             }
                             return sliced_array.items[0];
                         }
@@ -1729,13 +1741,28 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
                     .All => {
                         // Can be Array or Object
                         if (current_node.* != .array and current_node.* != .object) {
-                            return undefined;
+                            return null;
                         }
                         // Loop through all of the items in the current node and evaluate the rest of the path
                         path_index += 1;
-                        for (current_node.array.items) |item| {
-                            const evaluated_item = try evaluateJsonPathExpression(allocator, path[path_index..], &item, .{ .skip_root = true });
-                            sliced_array.append(evaluated_item.?) catch return JsonPathError.OutOfMemory;
+                        switch (current_node.*) {
+                            .array => {
+                                for (current_node.array.items) |item| {
+                                    const evaluated_item = try evaluateJsonPathExpression(allocator, path[path_index..], &item, .{ .skip_root = true });
+                                    if (evaluated_item) |evaluated| {
+                                        sliced_array.append(evaluated) catch return JsonPathError.OutOfMemory;
+                                    }
+                                }
+                            },
+                            .object => {
+                                for (current_node.object.values()) |item| {
+                                    const evaluated_item = try evaluateJsonPathExpression(allocator, path[path_index..], &item, .{ .skip_root = true });
+                                    if (evaluated_item) |evaluated| {
+                                        sliced_array.append(evaluated) catch return JsonPathError.OutOfMemory;
+                                    }
+                                }
+                            },
+                            else => unreachable,
                         }
                         return json.Value{ .array = sliced_array };
                     },
@@ -1757,6 +1784,63 @@ pub fn evaluateJsonPathExpression(allocator: std.mem.Allocator, path: []u8, valu
     }
     // We're at the end of the evaluation. We will return the value at the current node
     return current_node.*;
+}
+
+test "out-of-bounds indices produce no matches" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var root = try json.parseFromSliceLeaky(json.Value, allocator, "[0,1]", .{});
+
+    const single_path = try allocator.dupe(u8, "$[2]");
+    try testing.expectEqual(null, try evaluateJsonPathExpression(allocator, single_path, &root, .{}));
+
+    const multiple_path = try allocator.dupe(u8, "$[0,2]");
+    const multiple = (try evaluateJsonPathExpression(allocator, multiple_path, &root, .{})).?;
+    try testing.expectEqual(@as(usize, 1), multiple.array.items.len);
+    try testing.expectEqual(@as(i64, 0), multiple.array.items[0].integer);
+}
+
+test "selectors on incompatible node kinds produce no matches" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var array = try json.parseFromSliceLeaky(json.Value, allocator, "[]", .{});
+    var object = try json.parseFromSliceLeaky(json.Value, allocator, "{}", .{});
+
+    const name_path = try allocator.dupe(u8, "$['a']");
+    try testing.expectEqual(null, try evaluateJsonPathExpression(allocator, name_path, &array, .{}));
+
+    const index_path = try allocator.dupe(u8, "$[0]");
+    try testing.expectEqual(null, try evaluateJsonPathExpression(allocator, index_path, &object, .{}));
+}
+
+test "zero-step and serial slices safely produce empty selections" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var root = try json.parseFromSliceLeaky(json.Value, allocator, "[0,1,2]", .{});
+
+    const zero_step_path = try allocator.dupe(u8, "$[1:2:0]");
+    const zero_step = (try evaluateJsonPathExpression(allocator, zero_step_path, &root, .{})).?;
+    try testing.expectEqual(@as(usize, 0), zero_step.array.items.len);
+
+    const serial_path = try allocator.dupe(u8, "$[1:3][::]");
+    const serial = (try evaluateJsonPathExpression(allocator, serial_path, &root, .{})).?;
+    try testing.expectEqual(@as(usize, 0), serial.array.items.len);
+}
+
+test "malformed and control-character names are rejected" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var root: json.Value = .null;
+
+    const malformed_path = try allocator.dupe(u8, "$['");
+    try testing.expectError(JsonPathError.InvalidPath, evaluateJsonPathExpression(allocator, malformed_path, &root, .{}));
+
+    const control_path = try allocator.dupe(u8, "$['\x01']");
+    try testing.expectError(JsonPathError.InvalidPath, evaluateJsonPathExpression(allocator, control_path, &root, .{}));
 }
 
 const book_store_json =

--- a/tests/cts_runner.zig
+++ b/tests/cts_runner.zig
@@ -1,0 +1,244 @@
+const std = @import("std");
+const jsonpath = @import("jsonpath");
+
+const Cts = struct {
+    tests: []const TestCase,
+};
+
+const TestCase = struct {
+    name: []const u8,
+    selector: []const u8,
+    document: ?std.json.Value = null,
+    result: ?[]const std.json.Value = null,
+    results: ?[]const []const std.json.Value = null,
+    invalid_selector: bool = false,
+};
+
+const Outcome = enum {
+    valid_pass,
+    valid_fail,
+    invalid_rejected,
+    invalid_accepted,
+};
+
+const Counts = struct {
+    valid_pass: usize = 0,
+    valid_fail: usize = 0,
+    invalid_rejected: usize = 0,
+    invalid_accepted: usize = 0,
+    crash: usize = 0,
+
+    fn record(counts: *Counts, outcome: Outcome) void {
+        switch (outcome) {
+            .valid_pass => counts.valid_pass += 1,
+            .valid_fail => counts.valid_fail += 1,
+            .invalid_rejected => counts.invalid_rejected += 1,
+            .invalid_accepted => counts.invalid_accepted += 1,
+        }
+    }
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    const arena = init.arena.allocator();
+    const args = try init.minimal.args.toSlice(arena);
+    if (args.len < 2) return error.MissingCtsPath;
+
+    const cts_path = args[1];
+    const cts_source = try readFileAlloc(init.io, arena, cts_path);
+    const cts = try std.json.parseFromSliceLeaky(Cts, arena, cts_source, .{
+        .ignore_unknown_fields = true,
+    });
+
+    if (args.len == 4 and std.mem.eql(u8, args[2], "--worker")) {
+        const index = try std.fmt.parseInt(usize, args[3], 10);
+        if (index >= cts.tests.len) return error.InvalidCaseIndex;
+        return runWorker(arena, init.io, cts.tests[index]);
+    }
+
+    if (args.len != 2) return error.InvalidArguments;
+    return runController(init.gpa, init.io, args[0], cts_path, cts.tests);
+}
+
+fn readFileAlloc(io: std.Io, allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+
+    var buffer: [4096]u8 = undefined;
+    var reader = file.reader(io, &buffer);
+    return reader.interface.allocRemaining(allocator, .unlimited);
+}
+
+fn runController(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    executable: []const u8,
+    cts_path: []const u8,
+    tests: []const TestCase,
+) !u8 {
+    var counts: Counts = .{};
+
+    for (tests, 0..) |test_case, index| {
+        var index_buffer: [32]u8 = undefined;
+        const index_arg = try std.fmt.bufPrint(&index_buffer, "{}", .{index});
+        const result = try std.process.run(allocator, io, .{
+            .argv = &.{ executable, cts_path, "--worker", index_arg },
+            .stdout_limit = .limited(64),
+            .stderr_limit = .limited(64 * 1024),
+        });
+        defer allocator.free(result.stdout);
+        defer allocator.free(result.stderr);
+
+        const completed = switch (result.term) {
+            .exited => |code| code == 0,
+            else => false,
+        };
+        if (!completed) {
+            counts.crash += 1;
+            std.debug.print("CRASH [{}/{}] {s}\n", .{ index + 1, tests.len, test_case.name });
+            if (result.stderr.len > 0) std.debug.print("{s}\n", .{result.stderr});
+            continue;
+        }
+
+        const outcome_name = std.mem.trim(u8, result.stdout, " \t\r\n");
+        const outcome = std.meta.stringToEnum(Outcome, outcome_name) orelse {
+            counts.crash += 1;
+            std.debug.print("CRASH [{}/{}] {s}: malformed worker output: {s}\n", .{
+                index + 1,
+                tests.len,
+                test_case.name,
+                outcome_name,
+            });
+            continue;
+        };
+        counts.record(outcome);
+    }
+
+    std.debug.print(
+        \\JSONPath CTS ({d} cases)
+        \\  valid pass:       {d}
+        \\  valid fail:       {d}
+        \\  invalid rejected: {d}
+        \\  invalid accepted: {d}
+        \\  crashes:          {d}
+        \\
+    , .{
+        tests.len,
+        counts.valid_pass,
+        counts.valid_fail,
+        counts.invalid_rejected,
+        counts.invalid_accepted,
+        counts.crash,
+    });
+
+    return if (counts.crash == 0) 0 else 1;
+}
+
+fn runWorker(allocator: std.mem.Allocator, io: std.Io, test_case: TestCase) !u8 {
+    var root = test_case.document orelse std.json.Value.null;
+    const selector = try allocator.dupe(u8, test_case.selector);
+
+    const actual = jsonpath.evaluateJsonPathExpression(allocator, selector, &root, .{}) catch {
+        return writeOutcome(io, if (test_case.invalid_selector) .invalid_rejected else .valid_fail);
+    };
+
+    if (test_case.invalid_selector) return writeOutcome(io, .invalid_accepted);
+    return writeOutcome(io, if (matchesExpected(actual, test_case)) .valid_pass else .valid_fail);
+}
+
+fn writeOutcome(io: std.Io, outcome: Outcome) !u8 {
+    var buffer: [64]u8 = undefined;
+    var stdout = std.Io.File.stdout().writerStreaming(io, &buffer);
+    try stdout.interface.print("{s}\n", .{@tagName(outcome)});
+    try stdout.interface.flush();
+    return 0;
+}
+
+fn matchesExpected(actual: ?std.json.Value, test_case: TestCase) bool {
+    if (test_case.result) |expected| {
+        if (matchesNodelist(actual, expected)) return true;
+    }
+    if (test_case.results) |alternatives| {
+        for (alternatives) |expected| {
+            if (matchesNodelist(actual, expected)) return true;
+        }
+    }
+    return false;
+}
+
+// The legacy API represents both JSON array nodes and nodelists as json.Value.array.
+// Until issue #17 separates those concepts, accept either interpretation.
+fn matchesNodelist(actual: ?std.json.Value, expected: []const std.json.Value) bool {
+    const value = actual orelse return expected.len == 0;
+
+    if (expected.len == 1 and jsonValueEqual(value, expected[0])) return true;
+    return switch (value) {
+        .array => |array| jsonArrayEqual(array.items, expected),
+        else => false,
+    };
+}
+
+fn jsonArrayEqual(left: []const std.json.Value, right: []const std.json.Value) bool {
+    if (left.len != right.len) return false;
+    for (left, right) |left_value, right_value| {
+        if (!jsonValueEqual(left_value, right_value)) return false;
+    }
+    return true;
+}
+
+fn jsonValueEqual(left: std.json.Value, right: std.json.Value) bool {
+    if (std.meta.activeTag(left) != std.meta.activeTag(right)) return false;
+    return switch (left) {
+        .null => true,
+        .bool => |value| value == right.bool,
+        .integer => |value| value == right.integer,
+        .float => |value| value == right.float,
+        .number_string => |value| std.mem.eql(u8, value, right.number_string),
+        .string => |value| std.mem.eql(u8, value, right.string),
+        .array => |value| jsonArrayEqual(value.items, right.array.items),
+        .object => |value| {
+            if (value.count() != right.object.count()) return false;
+            var iterator = value.iterator();
+            while (iterator.next()) |entry| {
+                const right_value = right.object.get(entry.key_ptr.*) orelse return false;
+                if (!jsonValueEqual(entry.value_ptr.*, right_value)) return false;
+            }
+            return true;
+        },
+    };
+}
+
+test "legacy result adapter distinguishes an array node from a nodelist" {
+    const allocator = std.testing.allocator;
+    var actual_array = std.json.Array.init(allocator);
+    defer actual_array.deinit();
+    try actual_array.append(.{ .integer = 1 });
+    try actual_array.append(.{ .integer = 2 });
+    const actual = std.json.Value{ .array = actual_array };
+
+    var expected_array = std.json.Array.init(allocator);
+    defer expected_array.deinit();
+    try expected_array.append(.{ .integer = 1 });
+    try expected_array.append(.{ .integer = 2 });
+
+    try std.testing.expect(matchesNodelist(actual, &.{.{ .array = expected_array }}));
+    try std.testing.expect(matchesNodelist(actual, &.{ .{ .integer = 1 }, .{ .integer = 2 } }));
+}
+
+test "alternative results preserve order" {
+    var actual_array = std.json.Array.init(std.testing.allocator);
+    defer actual_array.deinit();
+    try actual_array.append(.{ .string = "B" });
+    try actual_array.append(.{ .string = "A" });
+
+    const alternatives = [_][]const std.json.Value{
+        &.{ .{ .string = "A" }, .{ .string = "B" } },
+        &.{ .{ .string = "B" }, .{ .string = "A" } },
+    };
+    const test_case: TestCase = .{
+        .name = "alternative order",
+        .selector = "$.*",
+        .results = &alternatives,
+    };
+
+    try std.testing.expect(matchesExpected(.{ .array = actual_array }, test_case));
+}


### PR DESCRIPTION
## Summary

- pin the official JSONPath CTS at `7be7c1fc28057c91e8eefaf197060fba7ed43acd`
- add a `zig build cts` controller that runs every case in an isolated worker process
- compare ordered results and alternative accepted result sequences through a temporary legacy-array adapter
- replace observable `undefined`, unchecked array access, wrong-kind union access, and unsafe optional unwraps in selector evaluation
- add focused regressions for out-of-bounds indices, wrong-node-kind selectors, zero-step/serial slices, and malformed/control-character names
- run the CTS in Debug and ReleaseSafe in CI with Zig 0.16.0
- document the pinned revision, command, and current baseline

## Baseline

| Outcome | Count |
| --- | ---: |
| Valid pass | 109 |
| Valid fail | 347 |
| Invalid rejected | 128 |
| Invalid accepted | 119 |
| Crash | 0 |

Semantic failures remain diagnostic in this characterization step. The CTS target fails only for a crash or an invalid worker result.

## Verification

- `zig build test --summary all` — 62/62 passed
- `zig build test -Doptimize=ReleaseSafe --summary all` — 62/62 passed
- `zig build cts` — 703 cases, 0 crashes
- `zig build cts -Doptimize=ReleaseSafe` — 703 cases, 0 crashes
- `zig fmt --check build.zig jsonpath.zig tests/cts_runner.zig`

Closes #15
